### PR TITLE
At some point legacy_api_password needed an api_password key

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -15,6 +15,7 @@ homeassistant:
   auth_providers:
     - type: homeassistant
     - type: legacy_api_password
+      api_password: !secret http_password
 
 # Enables the frontend
 frontend:


### PR DESCRIPTION
Boo for tests not picking this up :(